### PR TITLE
pushprox: fix hardcoded ipv4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,10 +1,10 @@
-FROM golang:1.16.4-alpine3.13
+FROM golang:1.18-alpine
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
-RUN go get golang.org/x/tools/cmd/goimports
+#RUN go install golang.org/x/tools/cmd/goimports
 RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
     fi

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -51,7 +51,7 @@ var (
 	metricsAddr        = kingpin.Flag("metrics-addr", "Serve Prometheus metrics at this address").Default(":9369").String()
 	tokenPath          = kingpin.Flag("token-path", "Uses an OAuth 2.0 Bearer token found in this path to make scrape requests").String()
 	insecureSkipVerify = kingpin.Flag("insecure-skip-verify", "Disable SSL security checks for client").Default("false").Bool()
-	useLocalhost       = kingpin.Flag("use-localhost", "Use 127.0.0.1 to scrape metrics instead of FQDN").Default("false").Bool()
+	useLocalhost       = kingpin.Flag("use-localhost", "Use localhost to scrape metrics instead of FQDN").Default("false").Bool()
 	allowPort          = kingpin.Flag("allow-port", "Restricts the proxy to only being allowed to scrape the given port").Default("*").String()
 
 	retryInitialWait = kingpin.Flag("proxy.retry.initial-wait", "Amount of time to wait after proxy failure").Default("1s").Duration()
@@ -154,7 +154,7 @@ func (c *Coordinator) doScrape(request *http.Request, client *http.Client) {
 			return
 		}
 		if useLocalhost != nil && *useLocalhost {
-			request.URL.Host = fmt.Sprintf("127.0.0.1:%s", port)
+			request.URL.Host = fmt.Sprintf("localhost:%s", port)
 		}
 	}
 


### PR DESCRIPTION
the --use-localhost flag doesn't account for ipv6 only clusters. This small PR fixe the issue.

I have no idea how to fix properly Dockerfile.dapper, the changes I introduced allowed me to build the image and test it locally, fixing my issue, but most probably one need to make some changes/updates to the Dockerfile