### PR TITLE
Authenticate GHA when pushing images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rancher/observation-backup

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
       - 'CODEOWNERS'
       - 'LICENSE'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name : Build, test  & validate

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,16 @@ jobs:
   push:
     name : Build and push PushProx images 
     runs-on : ubuntu-latest
+    permissions:
+      contents : read
+      id-token: write
     steps:
+      - name : "Read Secrets"
+        uses : rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials password | DOCKER_PASSWORD
       - name : Checkout repository
         uses: actions/checkout@v4
       - name : Setup go
@@ -25,8 +34,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
       - name : Build, test & validate
         run : make ci
         # setup tag name
@@ -39,7 +48,7 @@ jobs:
           context: .
           file: Dockerfile.proxy
           push: true
-          tags: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/pushprox-client:${{ env.TAG_NAME }}-client
+          tags: ${{ env.REGISTRY }}/rancher/pushprox-client:${{ env.TAG_NAME }}-client
           platforms: linux/amd64,linux/arm64
       - name: Build and push PushProx proxy image
         uses: docker/build-push-action@v5
@@ -47,5 +56,5 @@ jobs:
           context: .
           file: Dockerfile.client
           push: true
-          tags: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/pushprox-proxy:${{ env.TAG_NAME }}-proxy
+          tags: ${{ env.REGISTRY }}/rancher/pushprox-proxy:${{ env.TAG_NAME }}-proxy
           platforms : linux/amd64,linux/arm64


### PR DESCRIPTION
- Add a CODEOWNERS file

- Follow recommended procedures for authenticating via Docker
- Scope permissions explicitly to read in CI jobs