### PR TITLE
fix(ci): correct renovate config to prevent bumps we are not ready for

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,44 @@
 {
   "extends": [
     "github>rancher/renovate-config#release",
-    "group:all"
+    "group:all",
+    "helpers:pinGitHubActionDigests"
   ],
-  "baseBranches": ["master"]
+  "baseBranches": ["master"],
+  "packageRules": [
+    {
+      "groupName": "GitHub Workflow Actions",
+      "groupSlug": "gha-deps",
+      "matchManagers": [
+        "github-actions"
+      ]
+    },
+    {
+      "groupName": "Docker File Deps",
+      "groupSlug": "docker-bumps",
+      "matchManagers": [
+        "dockerfile"
+      ]
+    },
+    {
+      "matchBaseBranches": ["master"],
+      "matchPackageNames": [
+        "golang"
+      ],
+      "allowedVersions": "<1.24.0"
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "allowedVersions": "<1.24.0"
+    },
+    {
+      "matchPackageNames": [
+        "/^github.com/cenkalti/backoff/"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
This adjusts renovate to:

- Pin GHA to digests,
- Add groups for "GHA changes" and "docker file deps"
- Limit golang to `<1.24`
- disable major version bumps for `backoff` package