### PR TITLE
Update golangci-lint version used in dockerfile

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.suse.com/bci/golang:1.23 AS builder
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.1.6
 WORKDIR /usr/src/app
 COPY ../go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Updating the version of `golangci-lint` used in the project's dockerfile