### PR TITLE
feat: Allow Client and Proxy tags/repo to be set via global chart

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -6,6 +6,46 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "proxy.imageRepo" -}}
+{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
+{{- default .Values.proxy.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.proxyImage.repository) -}}
+{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
+{{- default .Values.proxy.image.repository .Values.global.pushProx.image.repository -}}
+{{ else }}
+{{- .Values.proxy.image.repository -}}
+{{ end }}
+{{- end -}}
+
+{{- define "proxy.imageTag" -}}
+{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
+{{- default .Values.proxy.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.proxyImage.tag) -}}
+{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
+{{- default .Values.proxy.image.tag .Values.global.pushProx.image.tag -}}
+{{ else }}
+{{- .Values.proxy.image.tag -}}
+{{ end }}
+{{- end -}}
+
+{{- define "clients.imageRepo" -}}
+{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
+{{- default .Values.clients.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.clientsImage.repository) -}}
+{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
+{{- default .Values.clients.image.repository .Values.global.pushProx.image.repository -}}
+{{ else }}
+{{- .Values.clients.image.repository -}}
+{{ end }}
+{{- end -}}
+
+{{- define "clients.imageTag" -}}
+{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
+{{- default .Values.clients.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.clientsImage.tag) -}}
+{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
+{{- default .Values.clients.image.tag .Values.global.pushProx.image.tag -}}
+{{ else }}
+{{- .Values.clients.image.tag -}}
+{{ end }}
+{{- end -}}
+
 # Windows Support
 
 {{/*

--- a/chart/templates/pushprox-clients.yaml
+++ b/chart/templates/pushprox-clients.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: pushprox-client
-        image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
+        image: {{ template "system_default_registry" . }}{{ template "clients.imageRepo" . }}:{{ template "clients.imageTag" . }}
         command:
         {{- range .Values.clients.command }}
           - {{ . | quote }}

--- a/chart/templates/pushprox-proxy.yaml
+++ b/chart/templates/pushprox-proxy.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: pushprox-proxy
-        image: {{ template "system_default_registry" . }}{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}
+        image: {{ template "system_default_registry" . }}{{ template "proxy.imageRepo" . }}:{{ template "proxy.imageTag" . }}
         command:
         {{- range .Values.proxy.command }}
           - {{ . | quote }}


### PR DESCRIPTION
Once merged in (and updated in Monitoring) we can update Monitoring charts to have this added to the global section:

```
  ## Global overrides for PushProx image values
  # pushProx:
  #   image:
  #     repository: rancher/pushprox
  #     tag: "YOUR VERSION"
  ## Alternatively, specify different client/proxy images via:
  #   proxyImage:
  #     repository: rancher/pushprox-proxy
  #     tag: "YOUR VERSION"
  #   clientsImage:
  #     repository: rancher/pushprox-client
  #     tag: "YOUR VERSION"
  ```
  
In turn this will allow end-users, and our team when doing testing, to swap out the pushprox images all in one fell-swoop instead of having to target each sub-chart for update. As shown above it primarily supports the new "single image model" that we are using today; but also can allow for the "split images for client and proxy" model like our older versions.
 
 ## Future consideration

This only covers controlling the images so far, however this leaves some potential room for improvements if we find them necessary later. Specifically the main one that comes to mind is the ability to control the entrypoint used for the image. This option to configure would have to fall under `proxyImage` and `proxyImage` so is intentionally left out of scope of this change.