### PR TITLE
fix: correct chart image global overrides bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,5 +29,11 @@ jobs:
         uses : actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version: 1.23
+      - name: Install helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - name : CI
         run : make ci

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,7 +4,7 @@ annotations:
   catalog.rancher.io/certified: rancher
   catalog.rancher.io/namespace: cattle-monitoring-system
   catalog.rancher.io/release-name: rancher-pushprox
-apiVersion: v1
+apiVersion: v2
 appVersion: v9.9.9
 description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
   clients.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -6,45 +6,45 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "proxy.imageRepo" -}}
-{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
-{{- default .Values.proxy.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.proxyImage.repository) -}}
+{{ define "proxy.imageRepo" -}}
+{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
+{{ default .Values.proxy.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.proxyImage.repository) }}
 {{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{- default .Values.proxy.image.repository .Values.global.pushProx.image.repository -}}
+{{ default .Values.proxy.image.repository .Values.global.pushProx.image.repository }}
 {{ else }}
 {{- .Values.proxy.image.repository -}}
 {{ end }}
-{{- end -}}
+{{ end -}}
 
-{{- define "proxy.imageTag" -}}
-{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
-{{- default .Values.proxy.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.proxyImage.tag) -}}
+{{ define "proxy.imageTag" -}}
+{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
+{{ default .Values.proxy.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.proxyImage.tag) }}
 {{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{- default .Values.proxy.image.tag .Values.global.pushProx.image.tag -}}
+{{ default .Values.proxy.image.tag .Values.global.pushProx.image.tag }}
 {{ else }}
 {{- .Values.proxy.image.tag -}}
 {{ end }}
-{{- end -}}
+{{ end -}}
 
-{{- define "clients.imageRepo" -}}
-{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
-{{- default .Values.clients.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.clientsImage.repository) -}}
+{{ define "clients.imageRepo" -}}
+{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
+{{ default .Values.clients.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.clientsImage.repository) }}
 {{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{- default .Values.clients.image.repository .Values.global.pushProx.image.repository -}}
+{{ default .Values.clients.image.repository .Values.global.pushProx.image.repository }}
 {{ else }}
 {{- .Values.clients.image.repository -}}
 {{ end }}
-{{- end -}}
+{{ end -}}
 
-{{- define "clients.imageTag" -}}
-{{ if and .Values.global.pushProx (and .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
-{{- default .Values.clients.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.clientsImage.tag) -}}
+{{ define "clients.imageTag" -}}
+{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
+{{ default .Values.clients.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.clientsImage.tag) }}
 {{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{- default .Values.clients.image.tag .Values.global.pushProx.image.tag -}}
+{{ default .Values.clients.image.tag .Values.global.pushProx.image.tag }}
 {{ else }}
 {{- .Values.clients.image.tag -}}
 {{ end }}
-{{- end -}}
+{{ end -}}
 
 # Windows Support
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{- end -}}
 {{- end -}}
 
-{{ define "proxy.imageRepo" -}}
+{{ define "pushProxy.proxy.imageRepo" -}}
 {{- $default := .Values.proxy.image.repository -}}
 {{- $override1 := "" -}}
 {{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "proxyImage") (hasKey .Values.global.pushProx.proxyImage "repository") -}}
@@ -27,7 +27,7 @@
 {{- end -}}
 {{- end -}}
 
-{{ define "proxy.imageTag" -}}
+{{ define "pushProxy.proxy.imageTag" -}}
 {{- $default := .Values.proxy.image.tag -}}
 {{- $override1 := "" -}}
 {{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "proxyImage") (hasKey .Values.global.pushProx.proxyImage "tag") -}}
@@ -48,16 +48,16 @@
 {{- end -}}
 {{- end -}}
 
-{{ define "proxy.container" -}}
+{{ define "pushProxy.proxy.container" -}}
 {{/*
   This template constructs the full image name for the proxy,
   including the registry, repository, and tag.
 */}}
-{{- template "system_default_registry" . -}}{{ template "proxy.imageRepo" . -}}:{{ template "proxy.imageTag" . -}}
+{{- template "system_default_registry" . -}}{{ template "pushProxy.proxy.imageRepo" . -}}:{{ template "pushProxy.proxy.imageTag" . -}}
 {{- end -}}
 
-{{ define "clients.imageRepo" -}}
-{{- $default := .Values.proxy.image.repository -}}
+{{ define "pushProxy.clients.imageRepo" -}}
+{{- $default := .Values.clients.image.repository -}}
 {{- $override1 := "" -}}
 {{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "clientsImage") (hasKey .Values.global.pushProx.clientsImage "repository") -}}
 {{- $override1 = .Values.global.pushProx.clientsImage.repository -}}
@@ -77,8 +77,8 @@
 {{- end -}}
 {{- end -}}
 
-{{ define "clients.imageTag" -}}
-{{- $default := .Values.proxy.image.tag -}}
+{{ define "pushProxy.clients.imageTag" -}}
+{{- $default := .Values.clients.image.tag -}}
 {{- $override1 := "" -}}
 {{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "clientsImage") (hasKey .Values.global.pushProx.clientsImage "tag") -}}
 {{- $override1 = .Values.global.pushProx.clientsImage.tag -}}
@@ -98,12 +98,12 @@
 {{- end -}}
 {{- end -}}
 
-{{ define "clients.container" -}}
+{{ define "pushProxy.clients.container" -}}
 {{/*
   This template constructs the full image name for the clients,
   including the registry, repository, and tag.
 */}}
-{{- template "system_default_registry" . -}}{{ template "clients.imageRepo" . -}}:{{ template "clients.imageTag" . -}}
+{{- template "system_default_registry" . -}}{{ template "pushProxy.clients.imageRepo" . -}}:{{ template "pushProxy.clients.imageTag" . -}}
 {{- end -}}
 
 # Windows Support

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -7,44 +7,104 @@
 {{- end -}}
 
 {{ define "proxy.imageRepo" -}}
-{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
-{{ default .Values.proxy.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.proxyImage.repository) }}
-{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{ default .Values.proxy.image.repository .Values.global.pushProx.image.repository }}
-{{ else }}
-{{- .Values.proxy.image.repository -}}
-{{ end }}
-{{ end -}}
+{{- $default := .Values.proxy.image.repository -}}
+{{- $override1 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "proxyImage") (hasKey .Values.global.pushProx.proxyImage "repository") -}}
+{{- $override1 = .Values.global.pushProx.proxyImage.repository -}}
+{{- end -}}
+
+{{- $override2 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "image") (hasKey .Values.global.pushProx.image "repository") -}}
+{{- $override2 = .Values.global.pushProx.image.repository -}}
+{{- end -}}
+
+{{- if ne $override1 "" -}}
+    {{- $override1 -}}
+{{- else if ne $override2 "" -}}
+    {{- $override2 -}}
+{{- else -}}
+    {{- $default -}}
+{{- end -}}
+{{- end -}}
 
 {{ define "proxy.imageTag" -}}
-{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.proxyImage) }}
-{{ default .Values.proxy.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.proxyImage.tag) }}
-{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{ default .Values.proxy.image.tag .Values.global.pushProx.image.tag }}
-{{ else }}
-{{- .Values.proxy.image.tag -}}
-{{ end }}
-{{ end -}}
+{{- $default := .Values.proxy.image.tag -}}
+{{- $override1 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "proxyImage") (hasKey .Values.global.pushProx.proxyImage "tag") -}}
+{{- $override1 = .Values.global.pushProx.proxyImage.tag -}}
+{{- end -}}
+
+{{- $override2 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "image") (hasKey .Values.global.pushProx.image "tag") -}}
+{{- $override2 = .Values.global.pushProx.image.tag -}}
+{{- end -}}
+
+{{- if ne $override1 "" -}}
+    {{- $override1 -}}
+{{- else if ne $override2 "" -}}
+    {{- $override2 -}}
+{{- else -}}
+    {{- $default -}}
+{{- end -}}
+{{- end -}}
+
+{{ define "proxy.container" -}}
+{{/*
+  This template constructs the full image name for the proxy,
+  including the registry, repository, and tag.
+*/}}
+{{- template "system_default_registry" . -}}{{ template "proxy.imageRepo" . -}}:{{ template "proxy.imageTag" . -}}
+{{- end -}}
 
 {{ define "clients.imageRepo" -}}
-{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
-{{ default .Values.clients.image.repository (default .Values.global.pushProx.image.repository .Values.global.pushProx.clientsImage.repository) }}
-{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{ default .Values.clients.image.repository .Values.global.pushProx.image.repository }}
-{{ else }}
-{{- .Values.clients.image.repository -}}
-{{ end }}
-{{ end -}}
+{{- $default := .Values.proxy.image.repository -}}
+{{- $override1 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "clientsImage") (hasKey .Values.global.pushProx.clientsImage "repository") -}}
+{{- $override1 = .Values.global.pushProx.clientsImage.repository -}}
+{{- end -}}
+
+{{- $override2 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "image") (hasKey .Values.global.pushProx.image "repository") -}}
+{{- $override2 = .Values.global.pushProx.image.repository -}}
+{{- end -}}
+
+{{- if ne $override1 "" -}}
+    {{- $override1 -}}
+{{- else if ne $override2 "" -}}
+    {{- $override2 -}}
+{{- else -}}
+    {{- $default -}}
+{{- end -}}
+{{- end -}}
 
 {{ define "clients.imageTag" -}}
-{{ if and .Values.global.pushProx (or .Values.global.pushProx.image .Values.global.pushProx.clientsImage) }}
-{{ default .Values.clients.image.tag (default .Values.global.pushProx.image.tag .Values.global.pushProx.clientsImage.tag) }}
-{{ else if and .Values.global.pushProx .Values.global.pushProx.image }}
-{{ default .Values.clients.image.tag .Values.global.pushProx.image.tag }}
-{{ else }}
-{{- .Values.clients.image.tag -}}
-{{ end }}
-{{ end -}}
+{{- $default := .Values.proxy.image.tag -}}
+{{- $override1 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "clientsImage") (hasKey .Values.global.pushProx.clientsImage "tag") -}}
+{{- $override1 = .Values.global.pushProx.clientsImage.tag -}}
+{{- end -}}
+
+{{- $override2 := "" -}}
+{{- if and (hasKey .Values "global") (hasKey .Values.global "pushProx") (hasKey .Values.global.pushProx "image") (hasKey .Values.global.pushProx.image "tag") -}}
+{{- $override2 = .Values.global.pushProx.image.tag -}}
+{{- end -}}
+
+{{- if ne $override1 "" -}}
+    {{- $override1 -}}
+{{- else if ne $override2 "" -}}
+    {{- $override2 -}}
+{{- else -}}
+    {{- $default -}}
+{{- end -}}
+{{- end -}}
+
+{{ define "clients.container" -}}
+{{/*
+  This template constructs the full image name for the clients,
+  including the registry, repository, and tag.
+*/}}
+{{- template "system_default_registry" . -}}{{ template "clients.imageRepo" . -}}:{{ template "clients.imageTag" . -}}
+{{- end -}}
 
 # Windows Support
 

--- a/chart/templates/pushprox-clients.yaml
+++ b/chart/templates/pushprox-clients.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: pushprox-client
-        image: {{ template "system_default_registry" . }}{{ template "clients.imageRepo" . }}:{{ template "clients.imageTag" . }}
+        image: {{ template "clients.container" . }}
         command:
         {{- range .Values.clients.command }}
           - {{ . | quote }}

--- a/chart/templates/pushprox-clients.yaml
+++ b/chart/templates/pushprox-clients.yaml
@@ -1,5 +1,5 @@
 {{- template "applyKubeVersionOverrides" . -}}
-{{- if .Values.clients }}{{- if .Values.clients.enabled }}
+{{- if and .Values.clients .Values.clients.enabled }}
 apiVersion: apps/v1
 {{- if .Values.clients.deployment.enabled }}
 kind: Deployment
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: pushprox-client
-        image: {{ template "clients.container" . }}
+        image: {{ template "pushProxy.clients.container" . }}
         command:
         {{- range .Values.clients.command }}
           - {{ . | quote }}
@@ -154,4 +154,4 @@ spec:
       - name: metrics-cert-dir
         emptyDir: {}
       {{- end }}
-{{- end }}{{- end }}
+{{- end }}

--- a/chart/templates/pushprox-proxy.yaml
+++ b/chart/templates/pushprox-proxy.yaml
@@ -1,5 +1,5 @@
 {{- template "applyKubeVersionOverrides" . -}}
-{{- if and .Values.proxy }}{{ if .Values.proxy.enabled }}
+{{- if and .Values.proxy .Values.proxy.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: pushprox-proxy
-        image: {{ template "proxy.container" . }}
+        image: {{ template "pushProxy.proxy.container" . }}
         command:
         {{- range .Values.proxy.command }}
           - {{ . | quote }}
@@ -54,4 +54,4 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.proxy.port }}
   selector: {{ include "pushProxy.proxy.labels" . | nindent 4 }}
-{{- end }}{{- end }}
+{{- end }}

--- a/chart/templates/pushprox-proxy.yaml
+++ b/chart/templates/pushprox-proxy.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: pushprox-proxy
-        image: {{ template "system_default_registry" . }}{{ template "proxy.imageRepo" . }}:{{ template "proxy.imageTag" . }}
+        image: {{ template "proxy.container" . }}
         command:
         {{- range .Values.proxy.command }}
           - {{ . | quote }}

--- a/chart/tests/clients_daemonset_image_test.yaml
+++ b/chart/tests/clients_daemonset_image_test.yaml
@@ -1,0 +1,98 @@
+suite: Clients Image Override Tests
+templates:
+  - pushprox-clients.yaml
+
+# Baseline values for the entire test suite.
+# Each 'test' will inherit these values unless explicitly overridden.
+set:
+  component: "client-unittest"
+  clients:
+    image:
+      tag: unittest-clients
+  proxy:
+    image:
+      tag: unittest-proxy
+
+tests:
+  - it: should be named pushprox-client-unittest-proxy
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    asserts:
+      - equal:
+          path: metadata.name
+          value: pushprox-client-unittest-client
+
+  - it: should have a container named pushprox-client
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: pushprox-client
+
+  - it: should use default clients image (from suite-level set)
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox:unittest-clients
+
+  - it: should use (local) clients override tag
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    set:
+      clients:
+        image:
+          tag: another-clients-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox:another-clients-tag
+
+  - it: should use (local) clients override repository
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    set:
+      clients:
+        image:
+          repository: unittest-repo/pushprox-clients
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: unittest-repo/pushprox-clients:unittest-clients
+
+  - it: should use (global) clients override tag and repository
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    set:
+      global:
+        pushProx:
+          clientsImage:
+            repository: rancher-global/pushprox-clients
+            tag: "global-clients-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher-global/pushprox-clients:global-clients-tag
+
+  - it: should use (global) generic image override if clientsImage isn't defined
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    set:
+      global:
+        pushProx:
+          image:
+            repository: generic-global/image
+            tag: "generic-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: generic-global/image:generic-tag

--- a/chart/tests/clients_deployment_image_test.yaml
+++ b/chart/tests/clients_deployment_image_test.yaml
@@ -1,0 +1,101 @@
+suite: Clients Image Override Tests
+templates:
+  - pushprox-clients.yaml
+
+# Baseline values for the entire test suite.
+# Each 'test' will inherit these values unless explicitly overridden.
+set:
+  component: "client-unittest"
+  clients:
+    deployment:
+      enabled:
+        true
+    image:
+      tag: unittest-clients
+  proxy:
+    image:
+      tag: unittest-proxy
+
+tests:
+  - it: should be named pushprox-client-unittest-proxy
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: metadata.name
+          value: pushprox-client-unittest-client
+
+  - it: should have a container named pushprox-client
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: pushprox-client
+
+  - it: should use default clients image (from suite-level set)
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox:unittest-clients
+
+  - it: should use (local) clients override tag
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      clients:
+        image:
+          tag: another-clients-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox:another-clients-tag
+
+  - it: should use (local) clients override repository
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      clients:
+        image:
+          repository: unittest-repo/pushprox-clients
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: unittest-repo/pushprox-clients:unittest-clients
+
+  - it: should use (global) clients override tag and repository
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      global:
+        pushProx:
+          clientsImage:
+            repository: rancher-global/pushprox-clients
+            tag: "global-clients-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher-global/pushprox-clients:global-clients-tag
+
+  - it: should use (global) generic image override if clientsImage isn't defined
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      global:
+        pushProx:
+          image:
+            repository: generic-global/image
+            tag: "generic-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: generic-global/image:generic-tag

--- a/chart/tests/proxy_deployment_image_test.yaml
+++ b/chart/tests/proxy_deployment_image_test.yaml
@@ -1,0 +1,117 @@
+suite: Proxy Image Override Tests
+templates:
+  - pushprox-proxy.yaml
+
+# Baseline values for the entire test suite.
+# Each 'test' will inherit these values unless explicitly overridden.
+set:
+  component: "proxy-unittest"
+  clients:
+    image:
+      tag: unittest-clients
+  proxy:
+    image:
+      tag: unittest-proxy
+
+tests:
+  - it: should be named pushprox-proxy-unittest-proxy
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: metadata.name
+          value: pushprox-proxy-unittest-proxy
+
+  - it: should have a container named pushprox-proxy
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: pushprox-proxy
+
+  - it: should use default image (from suite-level set)
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox:unittest-proxy
+
+  - it: should use (local) override tag
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      proxy:
+        image:
+          tag: another-proxy-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox:another-proxy-tag
+
+  - it: should use (local) override repository
+    documentSelector:
+      path: kind
+      value: Deployment
+    set: # Only specify what's different
+      proxy:
+        image:
+          repository: unittest-repo/pushprox
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: unittest-repo/pushprox:unittest-proxy
+
+  - it: should use (global) override tag and repository
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      global:
+        pushProx:
+          image:
+            repository: rancher-global/pushprox
+            tag: "global-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher-global/pushprox:global-tag
+
+  - it: should use (global) override tag and specific proxyImage repository
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      global:
+        pushProx:
+          image:
+            repository: rancher-global/pushprox
+            tag: "global-tag"
+          proxyImage:
+            repository: rancher/pushprox-proxy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher/pushprox-proxy:global-tag
+
+  - it: should use (global) override tag and specific proxyImage tag
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      global:
+        pushProx:
+          image:
+            repository: rancher-global/pushprox
+            tag: "global-tag"
+          proxyImage:
+            tag: "proxy-only"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: rancher-global/pushprox:proxy-only

--- a/scripts/ci
+++ b/scripts/ci
@@ -7,3 +7,4 @@ cd $(dirname $0)
 ./test
 ./validate
 ./validate-ci
+./helm-unittest

--- a/scripts/helm-unittest
+++ b/scripts/helm-unittest
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# note: requires helm-unittest (https://github.com/helm-unittest/helm-unittest) to be installed beforehand
+# run in root of rancher - i.e. bash dev-scripts/helm-unittest.sh
+# change automated parts of templates
+
+source $(dirname $0)/package-helm
+
+# test - need to be in the chart directory during the test so it can find Chart.yaml
+cd ./build/chart
+helm lint ./
+helm unittest ./
+cd ..

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -19,7 +19,7 @@ if ! hash helm 2>/dev/null; then
     exit 1
 fi
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 source ./scripts/version
 
 
@@ -27,7 +27,7 @@ rm -rf build/chart
 mkdir -p build dist/artifacts
 cp -rf chart build/
 
-edit-chart ${HELM_CHART_VERSION} ${HELM_IMAGE_TAG}
+edit-chart "${HELM_CHART_VERSION}" "${HELM_IMAGE_TAG}"
 
 if ! package-chart; then
     echo "Packaging rancher-pushprox chart failed!"


### PR DESCRIPTION
This helps to fix the feedback @pankajsqe gave for https://github.com/rancher/ob-team-charts/pull/89

The feedback was given in a slack thread and he may create an issue to track the specific bug. However this PR should address the issue (and add helm-unittest to cover the same) and allow us to create a new RC for testing.